### PR TITLE
Add big-diff-warning CI check

### DIFF
--- a/.github/workflows/ci-policies.yml
+++ b/.github/workflows/ci-policies.yml
@@ -1,0 +1,11 @@
+name: CI Policies
+on: pull_request
+
+jobs:
+  warn-big-diff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: cornell-dti/big-diff-warning@master
+        env:
+          BOT_TOKEN: '${{ secrets.BOT_TOKEN }}'


### PR DESCRIPTION
### Summary
All DTI repos must have [big-diff-warning](https://github.com/cornell-dti/big-diff-warning) enabled to prevent against large PRs.

### Test Plan
PR comment.