### PR TITLE
Article Fetching Endpoints

### DIFF
--- a/server/endpoints/articles/articles_endpoints.ts
+++ b/server/endpoints/articles/articles_endpoints.ts
@@ -1,0 +1,14 @@
+import fetch from 'node-fetch';
+import { Article } from '../../types';
+
+function formatArticles(jsonArticles) {
+  const ArticlesResponse: Article[] = jsonArticles as Article[];
+  return ArticlesResponse;
+}
+
+export default function getArticles(req, res) {
+  fetch('https://news.cornell.edu/taxonomy/term/14242/json')
+    .then((response) => response.json())
+    .then((jsonResponse) => formatArticles(jsonResponse))
+    .then((formattedArticles) => res.send(formattedArticles));
+}

--- a/server/server.ts
+++ b/server/server.ts
@@ -18,6 +18,7 @@ import {
 } from './endpoints/majors_minors/majors_minors_endpoints';
 import { createClubs, deleteClubs, getClubs, updateClubs } from './endpoints/clubs/clubs_endpoints';
 import getEvents from './endpoints/events/events_endpoints';
+import getArticles from './endpoints/articles/articles_endpoints';
 // eslint-disable-next-line
 const serviceAccount = require('./designAtCornellServiceAccount.json');
 
@@ -150,9 +151,13 @@ app.post('/updateClub', async (req, res) => {
  * retrieving the desired event(s) via query parameters from the database and
  * storing them in a local array of type Event.
  */
-app.get('/getEvents', async (req, res) => {
-  getEvents(req, res);
-});
+app.get('/getEvents', getEvents);
+
+/**
+ * ARTICLES FETCHING OPERATIONS
+ */
+
+app.get('/getArticles', getArticles);
 
 app.get('/*', (req, res) => {
   res.sendFile(path.join(__dirname, '../design-at-cornell/build/', 'index.html'));

--- a/server/types.ts
+++ b/server/types.ts
@@ -289,3 +289,16 @@ export type Event = {
   description: string;
   location: string;
 };
+
+export type Article = {
+  id: string;
+  url: string;
+  title: string;
+  content_text: string;
+  image: string;
+  image_1x1: string;
+  date_published: string;
+  tags: string[];
+  image_featured: string;
+  image_alt: string;
+};


### PR DESCRIPTION
### Summary <!-- Required -->

In this PR, we fetch articles related to design to display on the articles page of the D@C website. The majority of the work to implement this feature was researching sources to grab articles from. We explored many different APIs that provide news articles about topics of your choice, but there were two main concerns.

1. The news articles were not exclusive to Cornell. 
2. There was pricing associated with making more than a certain amount of requests 

Thus after researching for a while, we came across https://news.cornell.edu/rss-feeds which provides recent stories in any field. Since there was a field for Architecture & Design, we found that this source can be useful for our articles page. 

All that was left to be done was to implement an endpoint to grab the articles data from the above API and format it into an object with the properties that we intend to display on our page. 

### Test Plan <!-- Required -->

We test our endpoint via Postman. As evident in the screenshot, our call to '/getArticles' returns a list of article objects with the fields that we intend to display on our own articles page.

<img width="910" alt="Screen Shot 2022-04-17 at 4 57 16 PM" src="https://user-images.githubusercontent.com/46412997/163731757-688ded4a-965d-41a9-a33c-670fb056c4b3.png">

