### PR TITLE
Grid debug

### DIFF
--- a/design-at-cornell/src/about/About.tsx
+++ b/design-at-cornell/src/about/About.tsx
@@ -20,7 +20,7 @@ const About: React.FC = () => (
         <br />
         <br />
         Contact <a href="mailto:mshepley@cornell.edu">mshepley@cornell.edu</a> for questions about
-        the project or <a href="mailto:hello@cornelldti.org">hello@cornelldti.org</a> for any
+        the project or <a href="mailto:designatcornell@gmail.com">designatcornell@gmail.com</a> for any
         technical issues.
       </p>
     </div>

--- a/design-at-cornell/src/about/About.tsx
+++ b/design-at-cornell/src/about/About.tsx
@@ -20,8 +20,8 @@ const About: React.FC = () => (
         <br />
         <br />
         Contact <a href="mailto:mshepley@cornell.edu">mshepley@cornell.edu</a> for questions about
-        the project or <a href="mailto:designatcornell@gmail.com">designatcornell@gmail.com</a> for any
-        technical issues.
+        the project or <a href="mailto:designatcornell@gmail.com">designatcornell@gmail.com</a> for
+        any technical issues.
       </p>
     </div>
   </div>

--- a/design-at-cornell/src/components/ContainerStyles.ts
+++ b/design-at-cornell/src/components/ContainerStyles.ts
@@ -62,8 +62,16 @@ export const ArticleBubbleVerticalFlex = styled(VerticalFlex)`
   margin: 1%;
 `;
 
-export const FacultyBubbleVerticalFlex = styled(VerticalFlex)`
-  width: 80%;
-  justify-content: space-around;
+export const FacultyBubbleLeftVerticalFlex = styled(VerticalFlex)`
+  width: 45%;
   background-color: ${colors.lightGray};
+`;
+
+export const FacultyBubbleRightVerticalFlex = styled(VerticalFlex)`
+  width: 55%;
+  padding: 5%;
+`;
+
+export const FacultyBubbleHorizontalFlex = styled(HorizontalFlex)`
+  height: 100%;
 `;

--- a/design-at-cornell/src/components/ContainerStyles.ts
+++ b/design-at-cornell/src/components/ContainerStyles.ts
@@ -59,9 +59,7 @@ export const SubComponentHorizontalFlex = styled.div`
 `;
 
 export const ArticleBubbleVerticalFlex = styled(VerticalFlex)`
-  width: 100%;
-  margin-left: 70px;
-  justify-content: space-evenly;
+  margin: 1%;
 `;
 
 export const FacultyBubbleVerticalFlex = styled(VerticalFlex)`

--- a/design-at-cornell/src/components/ContainerStyles.ts
+++ b/design-at-cornell/src/components/ContainerStyles.ts
@@ -63,8 +63,7 @@ export const ArticleBubbleVerticalFlex = styled(VerticalFlex)`
 `;
 
 export const FacultyBubbleVerticalFlex = styled(VerticalFlex)`
-  width: 450px;
-  height: 370px;
+  width: 80%;
   justify-content: space-around;
   background-color: ${colors.lightGray};
 `;

--- a/design-at-cornell/src/components/DashboardElementStyles.ts
+++ b/design-at-cornell/src/components/DashboardElementStyles.ts
@@ -32,15 +32,15 @@ export const ArticleBubbleContainer = styled(ElementContainer)`
 `;
 
 export const FacultyBubbleContainer = styled(ElementContainer)`
-  width: 370px;
-  height: 480px;
+  width: 23%;
+  height: auto;
+  margin: 2% 5%;
   box-shadow: 0px 0px 0px 0px;
 
   img {
-    margin: 15px;
     margin-bottom: 25px;
-    width: 290px;
-    height: 290px;
+    width: 100%;
+    aspect-ratio: 1/1;
     border-radius: 50%;
     border: 13px solid white;
     outline: 3px solid ${colors.purple};
@@ -48,9 +48,8 @@ export const FacultyBubbleContainer = styled(ElementContainer)`
 
   h1 {
     margin-top: 5px;
-    margin-left: 25%;
     margin-bottom: 20px;
-    width: 173px;
+    width: 100%;
     text-align: center;
     font-weight: 600;
     font-size: 18px;
@@ -59,9 +58,8 @@ export const FacultyBubbleContainer = styled(ElementContainer)`
   }
 
   p {
-    margin-left: 25%;
     margin-bottom: 10px;
-    width: 173px;
+    width: 100%;
     text-align: center;
     font-weight: 600;
     font-size: 16px;

--- a/design-at-cornell/src/components/DashboardElementStyles.ts
+++ b/design-at-cornell/src/components/DashboardElementStyles.ts
@@ -206,8 +206,6 @@ export const LargeArticleBubbleTitle = styled(Title)`
 `;
 
 export const FacultyBubbleTitle = styled(Title)`
-  margin-top: 36px;
-  margin-left: 22px;
   font-size: 14px;
   line-height: 21px;
 `;
@@ -248,8 +246,6 @@ export const LargeArticleBubbleSubtitle = styled(Subtitle)`
 export const FacultyBubbleSubtitle = styled(Subtitle)`
   p {
     width: 100%;
-    margin-top: 3px;
-    margin: 0px 22px;
     font-weight: normal;
     font-size: 14px;
     color: black;
@@ -266,11 +262,6 @@ export const TagsContainer = styled.div`
   width: 100%;
   height: fit-content;
   align-items: flex-start;
-`;
-
-export const FacultyBubbleTagsContainer = styled(TagsContainer)`
-  margin-left: 22px;
-  margin-bottom: 15px;
 `;
 
 export const Tag = styled.div`

--- a/design-at-cornell/src/components/DashboardElementStyles.ts
+++ b/design-at-cornell/src/components/DashboardElementStyles.ts
@@ -69,37 +69,14 @@ export const FacultyBubbleContainer = styled(ElementContainer)`
 `;
 
 export const SmallFacultyBubbleContainer = styled(FacultyBubbleContainer)`
-  width: 600px;
-  height: 370px;
-  margin: 20px 10px;
+  width: 46%;
+  margin: 2%;
   padding: 0px;
   box-shadow: 0px 0px 5px 2px ${colors.cardShadow};
 
   img {
-    margin-top: 30px;
-    margin-left: 50px;
-    width: 160px;
-    height: 160px;
-    border-radius: 50%;
-    border: 7px solid white;
-    outline: 1.5px solid ${colors.purple};
-  }
-
-  h1 {
-    text-align: center;
-    margin-left: 0px;
-    margin-top: -5px;
-    width: 260px;
-    font-size: 18px;
-    color: black;
-  }
-
-  p {
-    margin-top: 2px;
-    margin-left: 50px;
-    width: 160px;
-    font-size: 14px;
-    color: black;
+    width: 80%;
+    margin: 10%;
   }
 `;
 

--- a/design-at-cornell/src/components/DashboardElementStyles.ts
+++ b/design-at-cornell/src/components/DashboardElementStyles.ts
@@ -196,7 +196,7 @@ export const SmallArticleBubbleTitle = styled(Title)`
 `;
 
 export const LargeArticleBubbleTitle = styled(Title)`
-p {
+  p {
     margin-top: 10px;
     font-size: 36px;
     line-height: 42px;

--- a/design-at-cornell/src/components/DashboardElementStyles.ts
+++ b/design-at-cornell/src/components/DashboardElementStyles.ts
@@ -15,19 +15,20 @@ export const ElementContainer = styled.div`
   padding: 25px;
   align-items: flex-start;
   justify-content: space-between;
-
-  img {
-    margin: -25px;
-    width: 370px;
-    height: 220px;
-    border-radius: 20px 20px 0px 0px;
-  }
 `;
 
 export const ArticleBubbleContainer = styled(ElementContainer)`
-  width: 370px;
-  height: 350px;
+  width: 30%;
+  height: auto;
   border-radius: 20px;
+
+  img {
+    width: calc(100% + 50px);
+    height: auto;
+    aspect-ratio: 5/3;
+    margin: -25px 0px 0px -25px;
+    border-radius: 20px 20px 0px 0px;
+  }
 `;
 
 export const FacultyBubbleContainer = styled(ElementContainer)`
@@ -105,25 +106,28 @@ export const SmallFacultyBubbleContainer = styled(FacultyBubbleContainer)`
 `;
 
 export const SmallArticleBubbleContainer = styled(ElementContainer)`
-  width: 270px;
-  height: 325px;
+  height: auto;
   border-radius: 20px;
 
   img {
-    width: 270px;
-    height: 180px;
+    width: calc(100% + 50px);
+    height: auto;
+    aspect-ratio: 3/2;
+    margin: -25px 25px 0px -25px;
+    border-radius: 20px 20px 0px 0px;
   }
 `;
 
 export const LargeArticleBubbleContainer = styled(ElementContainer)`
-  margin-left: 20px;
   width: 97%;
-  height: 350px;
+  height: auto;
   border-radius: 20px;
 
   img {
-    width: 50%;
-    height: 350px;
+    margin: -25px 25px -25px -25px;
+    width: auto;
+    height: calc(100% + 50px);
+    aspect-ratio: 5/3;
     border-radius: 20px 0px 0px 20px;
   }
 `;
@@ -192,9 +196,17 @@ export const ClubBubbleTitle = styled(Title)`
   line-height: 21px;
 `;
 
+export const ArticleBubbleTitle = styled(Title)`
+  p {
+    margin-top: 20px;
+    width: 100%;
+    -webkit-line-clamp: 3;
+  }
+`;
+
 export const ArticleBubbleSubtitle = styled(Subtitle)`
   p {
-    margin-bottom: -5px;
+    margin-top: 8px;
     font-size: 12px;
     line-height: 18px;
   }
@@ -203,15 +215,19 @@ export const ArticleBubbleSubtitle = styled(Subtitle)`
 export const SmallArticleBubbleTitle = styled(Title)`
   p {
     margin-top: 5px;
-    width: 220px;
+    width: 100%;
     -webkit-line-clamp: 3;
   }
 `;
 
 export const LargeArticleBubbleTitle = styled(Title)`
-  margin-top: 5px;
-  font-size: 36px;
-  line-height: 42px;
+p {
+    margin-top: 10px;
+    font-size: 36px;
+    line-height: 42px;
+    width: 100%;
+    -webkit-line-clamp: 2;
+  }
 `;
 
 export const FacultyBubbleTitle = styled(Title)`
@@ -223,7 +239,7 @@ export const FacultyBubbleTitle = styled(Title)`
 
 export const SmallArticleBubbleDate = styled(Subtitle)`
   p {
-    margin-top: 40px;
+    margin-top: 20px;
     font-size: 11px;
     line-height: 13px;
   }
@@ -239,7 +255,6 @@ export const LargeArticleBubbleDate = styled(Subtitle)`
 export const SmallArticleBubbleSubtitle = styled(Subtitle)`
   p {
     margin-top: 5px;
-    margin-bottom: -5px;
     font-size: 12px;
     line-height: 18px;
     -webkit-line-clamp: 3;
@@ -248,6 +263,7 @@ export const SmallArticleBubbleSubtitle = styled(Subtitle)`
 
 export const LargeArticleBubbleSubtitle = styled(Subtitle)`
   p {
+    margin-top: 15px;
     font-size: 18px;
     line-height: 25px;
     -webkit-line-clamp: 4;

--- a/design-at-cornell/src/components/DashboardGridStyles.ts
+++ b/design-at-cornell/src/components/DashboardGridStyles.ts
@@ -49,7 +49,3 @@ export const Grid = styled.div`
   height: fit-content;
   padding: 0 80px;
 `;
-
-export const CommunityGrid = styled(Grid)`
-  justify-content: space-between;
-`;

--- a/design-at-cornell/src/design-community/design-articles/ArticleBubble.tsx
+++ b/design-at-cornell/src/design-community/design-articles/ArticleBubble.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {
   ArticleBubbleContainer,
-  Title,
+  ArticleBubbleTitle,
   ArticleBubbleSubtitle,
 } from '../../components/DashboardElementStyles';
 import { Article } from '../../../../server/src/types';
@@ -11,9 +11,9 @@ const ArticleBubble = (article: Article) => (
   <ArticleBubbleContainer onClick={() => window.open(article.url)}>
     <VerticalFlex>
       <img src={article.image_featured} alt={article.image_alt} />
-      <Title>
+      <ArticleBubbleTitle>
         <p>{article.title}</p>
-      </Title>
+      </ArticleBubbleTitle>
       <ArticleBubbleSubtitle>
         <p>{article.content_text}</p>
       </ArticleBubbleSubtitle>

--- a/design-at-cornell/src/design-community/design-articles/Dashboard.tsx
+++ b/design-at-cornell/src/design-community/design-articles/Dashboard.tsx
@@ -1,19 +1,19 @@
 import React from 'react';
 import { HorizontalFlex, VerticalFlex } from '../../components/ContainerStyles';
-import { CommunityGrid } from '../../components/DashboardGridStyles';
+import { Grid } from '../../components/DashboardGridStyles';
 import { HeadingLine } from '../../components/DashboardElementStyles';
 import { Article } from '../../../../server/src/types';
 import ArticleBubble from './ArticleBubble';
 
 const Dashboard = (article: Article[]) => {
   const articleBubbles = (
-    <CommunityGrid>
+    <Grid>
       {Object.values(article)
         .slice(0, 3)
         .map((article) => (
           <ArticleBubble key={article.id} {...article} />
         ))}
-    </CommunityGrid>
+    </Grid>
   );
 
   return (

--- a/design-at-cornell/src/design-community/design-articles/articles-page/Dashboard.tsx
+++ b/design-at-cornell/src/design-community/design-articles/articles-page/Dashboard.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { HorizontalFlex, VerticalFlex } from '../../../components/ContainerStyles';
-import { CommunityGrid } from '../../../components/DashboardGridStyles';
+import { Grid } from '../../../components/DashboardGridStyles';
 import { HeadingLine } from '../../../components/DashboardElementStyles';
 import { Article } from '../../../../../server/src/types';
 import ArticleBubble from './Bubble';
 import LargeArticleBubble from './LargeBubble';
 const Dashboard = (article: Article[]) => {
   const articleBubbles = (
-    <CommunityGrid>
+    <Grid>
       {Object.values(article)
         .slice(0, 1)
         .map((article) => (
@@ -18,7 +18,7 @@ const Dashboard = (article: Article[]) => {
         .map((article) => (
           <ArticleBubble key={article.id} {...article} />
         ))}
-    </CommunityGrid>
+    </Grid>
   );
 
   return (

--- a/design-at-cornell/src/design-community/design-articles/articles-page/LargeBubble.tsx
+++ b/design-at-cornell/src/design-community/design-articles/articles-page/LargeBubble.tsx
@@ -27,7 +27,9 @@ const LargeArticleBubble = (article: Article) => (
                 article.date_published.split(' ')[3]}
             </p>
           </LargeArticleBubbleDate>
-          <LargeArticleBubbleTitle>{article.title}</LargeArticleBubbleTitle>
+          <LargeArticleBubbleTitle>
+            <p>{article.title}</p>
+          </LargeArticleBubbleTitle>
           <LargeArticleBubbleSubtitle>
             <p>{article.content_text}</p>
           </LargeArticleBubbleSubtitle>

--- a/design-at-cornell/src/design-community/design-faculty/Dashboard.tsx
+++ b/design-at-cornell/src/design-community/design-faculty/Dashboard.tsx
@@ -1,19 +1,19 @@
 import React from 'react';
 import { HorizontalFlex, VerticalFlex } from '../../components/ContainerStyles';
-import { CommunityGrid } from '../../components/DashboardGridStyles';
+import { Grid } from '../../components/DashboardGridStyles';
 import { HeadingLine } from '../../components/DashboardElementStyles';
 import { Faculty } from '../../../../server/src/types';
 import FacultyBubble from './FacultyBubble';
 
 const Dashboard = (faculty: Faculty[]) => {
   const facultyBubbles = (
-    <CommunityGrid>
+    <Grid>
       {Object.values(faculty)
         .slice(0, 6)
         .map((faculty) => (
           <FacultyBubble key={faculty.name} {...faculty} />
         ))}
-    </CommunityGrid>
+    </Grid>
   );
 
   return (

--- a/design-at-cornell/src/design-community/design-faculty/faculty-page/Bubble.tsx
+++ b/design-at-cornell/src/design-community/design-faculty/faculty-page/Bubble.tsx
@@ -3,28 +3,28 @@ import {
   SmallFacultyBubbleContainer,
   FacultyBubbleTitle,
   FacultyBubbleSubtitle,
-  FacultyBubbleTagsContainer,
+  TagsContainer,
   Tag,
 } from '../../../components/DashboardElementStyles';
 import {
-  HorizontalFlex,
-  VerticalFlex,
-  FacultyBubbleVerticalFlex,
+  FacultyBubbleLeftVerticalFlex,
+  FacultyBubbleRightVerticalFlex,
+  FacultyBubbleHorizontalFlex,
 } from '../../../components/ContainerStyles';
 import { Faculty } from '../../../../../server/src/types';
 import { dashboardColors } from '../../../constants/colors';
 
 const FacultyBubble = (faculty: Faculty) => (
   <SmallFacultyBubbleContainer onClick={() => window.open(faculty.website)}>
-    <HorizontalFlex>
-      <FacultyBubbleVerticalFlex>
+    <FacultyBubbleHorizontalFlex>
+      <FacultyBubbleLeftVerticalFlex>
         <img src={faculty.image} alt="faculty profile" />
         <h1>{faculty.name}</h1>
         <p>{faculty.title}</p>
         <p>{faculty.department}</p>
         <br></br>
-      </FacultyBubbleVerticalFlex>
-      <VerticalFlex>
+      </FacultyBubbleLeftVerticalFlex>
+      <FacultyBubbleRightVerticalFlex>
         <FacultyBubbleTitle>About {faculty.name}</FacultyBubbleTitle>
         <FacultyBubbleSubtitle>
           <p>{faculty.description}</p>
@@ -34,7 +34,7 @@ const FacultyBubble = (faculty: Faculty) => (
           {faculty.courses === undefined ? null : <p>{faculty.courses.join(', ')}</p>}
         </FacultyBubbleSubtitle>
         <br></br>
-        <FacultyBubbleTagsContainer>
+        <TagsContainer>
           {faculty.tags[0] === undefined ? null : (
             <Tag
               style={{
@@ -53,10 +53,10 @@ const FacultyBubble = (faculty: Faculty) => (
               {faculty.tags[1]}
             </Tag>
           )}
-        </FacultyBubbleTagsContainer>
+        </TagsContainer>
         <br></br>
-      </VerticalFlex>
-    </HorizontalFlex>
+      </FacultyBubbleRightVerticalFlex>
+    </FacultyBubbleHorizontalFlex>
   </SmallFacultyBubbleContainer>
 );
 

--- a/design-at-cornell/src/design-community/design-faculty/faculty-page/Dashboard.tsx
+++ b/design-at-cornell/src/design-community/design-faculty/faculty-page/Dashboard.tsx
@@ -2,16 +2,16 @@ import React from 'react';
 import { VerticalFlex } from '../../../components/ContainerStyles';
 import { TitleBackground, TitleContainer } from '../../../components/TitleStyles';
 import { colors } from '../../../constants/colors';
-import { CommunityGrid } from '../../../components/DashboardGridStyles';
+import { Grid } from '../../../components/DashboardGridStyles';
 import { Faculty } from '../../../../../server/src/types';
 import FacultyBubble from './Bubble';
 const Dashboard = (faculty: Faculty[]) => {
   const facultyBubbles = (
-    <CommunityGrid>
+    <Grid>
       {Object.values(faculty).map((faculty) => (
         <FacultyBubble key={faculty.name} {...faculty} />
       ))}
-    </CommunityGrid>
+    </Grid>
   );
 
   return (

--- a/design-at-cornell/src/explore-courses/courses/CourseBubble.tsx
+++ b/design-at-cornell/src/explore-courses/courses/CourseBubble.tsx
@@ -63,7 +63,6 @@ const CourseBubble = (course: Course) => {
           <Title>{course.content.title}</Title>
           <HorizontalFlex>
             <TagsContainer>
-              <Tag>{course.content.major}</Tag>
               <Tag>{course.content.semester.join(', ')}</Tag>
               {course.content.designAreas.filter((x) => x !== '').length === 0 ? null : (
                 <Tag>{course.content.designAreas.join(', ')}</Tag>

--- a/design-at-cornell/src/footer/Footer.tsx
+++ b/design-at-cornell/src/footer/Footer.tsx
@@ -22,9 +22,9 @@ const Footer = () => {
       <Email>
         <p>
           For any questions, please contact
-          <a href="mailto: hello@cornelldti.org" target="_blank" rel="noopener noreferrer">
+          <a href="mailto:designatcornell@gmail.com" target="_blank" rel="noopener noreferrer">
             {' '}
-            hello@cornelldti.org
+            designatcornell@gmail.com
           </a>
         </p>
       </Email>


### PR DESCRIPTION
This PR fixed the grid view of the design community, article, faculty pages
* Grid items resize dynamically relative to window width (use percentage instead of pixels for dimension)
* Align the last row of grid (removed `space-between` property)
* Fixed some text overflow issues