### PR TITLE
Fix cards to show 4/row

### DIFF
--- a/design-at-cornell/src/components/DashboardElementStyles.ts
+++ b/design-at-cornell/src/components/DashboardElementStyles.ts
@@ -5,7 +5,7 @@ export const ElementContainer = styled.div`
   display: flex;
   flex-direction: column;
   width: 22%;
-  min-width: 300px;
+  min-width: 280px;
   height: 197px;
   cursor: pointer;
   background: white;


### PR DESCRIPTION
### Summary <!-- Required -->

Decreases the minimum width for explore courses and club cards in order to show four cards in each row rather than three.