### PR TITLE
FA22 Setup Tweaks 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+
+
 # Logs
 logs
 *.log
@@ -13,6 +15,7 @@ firebase-debug.*.log*
 # Firebase config
 
 **/designAtCornellServiceAccount.json
+**/firebase-adminsdk.json
 
 # Uncomment this if you'd like others to create their own Firebase project.
 # For a team working on the same Firebase project(s), it is recommended to leave
@@ -78,3 +81,5 @@ node_modules/
 .env.production.local
 
 dist/
+
+

--- a/design-at-cornell/src/constants/util.ts
+++ b/design-at-cornell/src/constants/util.ts
@@ -3,8 +3,12 @@ import axios from 'axios';
 
 dotenv.config();
 
+// PROD: process.env.REACT_APP_BASE_URL
+// LOCAL: http://localhost:3000
+// Change to only local if you are testing backend functionality.
+
 const api = axios.create({
-  baseURL: process.env.REACT_APP_BASE_URL,
+  baseURL: process.env.REACT_APP_BASE_URL || 'http://localhost:3000',
 });
 
 export default api;


### PR DESCRIPTION
### Summary 

Git ignores `firebase-adminsdk.json`. 
Frontend endpoint in utils now can either be hitting the production or local environment server. 

`baseUrl = process.env.REACT_APP_BASE_URL` means the frontend will hit the production server and you don't need to spin the server locally. 

`baseUrl = localhost3000` means the frontend will hit the server you spun up on your computer => you have to run the backend. 

If only working on frontend features: 
- Keep the `env` variable and not the `localhost:3000` URL. 

If working on backend features: 
- Use the `localhost` 
