### PR TITLE
Fix area of studies filtering

### DIFF
--- a/design-at-cornell/src/areas-of-study/AreasOfStudy.tsx
+++ b/design-at-cornell/src/areas-of-study/AreasOfStudy.tsx
@@ -15,8 +15,9 @@ const AreasOfStudy = () => {
       }>('/getMajors')
       .then((res) => res.data.data)
       .then((allStudies) => {
-        const majors = allStudies.filter(({ content }) => content.type === 'Major');
-        const minors = allStudies.filter(({ content }) => content.type === 'Minor');
+        const underGradStudies = allStudies.filter(({ content }) => content.academicLevel === 'UG');
+        const majors = underGradStudies.filter(({ content }) => content.type === 'Major');
+        const minors = underGradStudies.filter(({ content }) => content.type === 'Minor');
         const gradStudies = allStudies.filter(({ content }) => content.academicLevel === 'G');
         setMajors(majors);
         setMinors(minors);

--- a/design-at-cornell/src/areas-of-study/dashboard/AreaOfStudyCard.tsx
+++ b/design-at-cornell/src/areas-of-study/dashboard/AreaOfStudyCard.tsx
@@ -6,10 +6,10 @@ import { Major } from '../../../../server/src/types';
 const AreaOfStudyCard = (props: Props) => {
   return (
     <AreaOfStudyButton
-      key={props.study.title}
+      key={props.study.content.title}
       onClick={() => window.open(props.study.content.departmentPage)}
     >
-      <h1>{props.study.title}</h1>
+      <h1>{props.study.content.title}</h1>
       <AreaOfStudyTag highlight={props.schoolTags[props.study.content.school]}>
         {props.study.content.school + '. '}
       </AreaOfStudyTag>

--- a/design-at-cornell/src/areas-of-study/dashboard/AreaOfStudyModal.tsx
+++ b/design-at-cornell/src/areas-of-study/dashboard/AreaOfStudyModal.tsx
@@ -24,8 +24,8 @@ const AreaOfStudyModal = (props: Props) => {
   const [open, setOpen] = React.useState(false);
 
   const areaOfStudyButton = (
-    <AreaOfStudyButton key={props.study.title}>
-      <h1>{props.study.title}</h1>
+    <AreaOfStudyButton key={props.study.content.title}>
+      <h1>{props.study.content.title}</h1>
       <AreaOfStudyTag highlight={props.schoolTags[props.study.content.school]}>
         {props.study.content.school + '. '}
       </AreaOfStudyTag>

--- a/server/scripts/majors_minors_script.ts
+++ b/server/scripts/majors_minors_script.ts
@@ -9,7 +9,7 @@ function createMajors(formatMajors: Major[]) {
   for (let i = 0; i < formatMajors.length; i += 1) {
     const newMajor = majors.doc(formatMajors[i].title);
     newMajor.set({
-      title: formatMajors[i].title,
+      title: formatMajors[i].content.title,
       academicLevel: formatMajors[i].content.academicLevel,
       departmentPage: formatMajors[i].content.departmentPage,
       designAreas: formatMajors[i].content.designAreas,
@@ -21,7 +21,7 @@ function createMajors(formatMajors: Major[]) {
 }
 
 fsMajorsRead
-  .createReadStream('./website_data_csv/majors2.csv')
+  .createReadStream('../website_data_csv/majors2.csv')
   .pipe(csv())
   .on('data', (data) => majorsCSV.push(data))
   .on('end', () => {
@@ -29,7 +29,7 @@ fsMajorsRead
     // converting each course (CSV object) into formatCourse (JSON object)
     for (let i = 0; i < majorsCSV.length; i += 1) {
       const fMajor: Major = {
-        title: majorsCSV[i].title,
+        title: majorsCSV[i].title + ', ' + majorsCSV[i].academicLevel + ', ' + majorsCSV[i].type,
         content: {
           academicLevel: majorsCSV[i].academicLevel,
           designAreas: majorsCSV[i].designAreas.split(', '),
@@ -37,6 +37,7 @@ fsMajorsRead
           school: majorsCSV[i].school,
           departmentPage: majorsCSV[i].departmentPage,
           type: majorsCSV[i].type,
+          title: majorsCSV[i].title,
         },
       };
       formattedMajors.push(fMajor);

--- a/server/scripts/majors_minors_script.ts
+++ b/server/scripts/majors_minors_script.ts
@@ -29,7 +29,7 @@ fsMajorsRead
     // converting each course (CSV object) into formatCourse (JSON object)
     for (let i = 0; i < majorsCSV.length; i += 1) {
       const fMajor: Major = {
-        title: majorsCSV[i].title + ', ' + majorsCSV[i].academicLevel + ', ' + majorsCSV[i].type,
+        title: `${majorsCSV[i].title},  ${majorsCSV[i].academicLevel}, ${majorsCSV[i].type}`,
         content: {
           academicLevel: majorsCSV[i].academicLevel,
           designAreas: majorsCSV[i].designAreas.split(', '),

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -18,6 +18,7 @@ export type Course = {
 };
 
 export type majorContent = {
+  title: string;
   academicLevel: string;
   departmentPage: string;
   designAreas: string[];


### PR DESCRIPTION
### Summary <!-- Required -->

This PR fixes the majors and minors backend script and frontend page to correctly add and filter through areas of studies. 

Before, areas of studies were added to the database using their title as the id. However, since the titles aren't unique, entries with the same name (ex: Psychology (major) and Psychology (minor), FSAD (undergrad) and FSAD (grad)) overwrote each other. This caused issues with incorrect links and incorrect majors/minors appearing on the page. 

Now, areas of studies are added to the database using their title, academic level, and type, which is unique. The frontend is updated to display the correct information as well.