### PR TITLE
Fix homepage alignment + hits prod backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ firebase-debug.*.log*
 
 **/designAtCornellServiceAccount.json
 **/firebase-adminsdk.json
+*/firebase-adminsdk.json
+server/resources/firebase-adminsdk.json
 
 # Uncomment this if you'd like others to create their own Firebase project.
 # For a team working on the same Firebase project(s), it is recommended to leave

--- a/design-at-cornell/src/constants/util.ts
+++ b/design-at-cornell/src/constants/util.ts
@@ -8,7 +8,9 @@ dotenv.config();
 // Change to only local if you are testing backend functionality.
 
 const api = axios.create({
-  baseURL: process.env.REACT_APP_BASE_URL || 'http://localhost:3000',
+  baseURL: process.env.REACT_APP_BASE_URL,
+  // baseURL: 'http://localhost:3000',
 });
 
 export default api;
+

--- a/design-at-cornell/src/constants/util.ts
+++ b/design-at-cornell/src/constants/util.ts
@@ -4,13 +4,12 @@ import axios from 'axios';
 dotenv.config();
 
 // PROD: process.env.REACT_APP_BASE_URL
-// LOCAL: http://localhost:3000
+// LOCAL: http://localhost:3000 >>
+//  baseURL: 'http://localhost:3000',
 // Change to only local if you are testing backend functionality.
 
 const api = axios.create({
   baseURL: process.env.REACT_APP_BASE_URL,
-  // baseURL: 'http://localhost:3000',
 });
 
 export default api;
-

--- a/design-at-cornell/src/static/images/community_icon.svg
+++ b/design-at-cornell/src/static/images/community_icon.svg
@@ -1,5 +1,5 @@
 <svg width="344" height="346" viewBox="0 0 344 346" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-<rect y="2" width="344" height="344" rx="20" fill="#FF8C38"/>
+<rect width="344" height="344" rx="20" fill="#FF8C38"/>
 <g style="mix-blend-mode:overlay">
 <rect width="344" height="344" rx="20" fill="url(#pattern0)"/>
 </g>

--- a/design-at-cornell/src/static/images/majors_minors.svg
+++ b/design-at-cornell/src/static/images/majors_minors.svg
@@ -1,7 +1,7 @@
-<svg width="344" height="346" viewBox="0 0 344 346" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="344" height="344" viewBox="0 0 344 344" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 <rect width="344" height="344" rx="20" fill="#8ED663"/>
 <g style="mix-blend-mode:overlay">
-<rect width="344" height="346" rx="20" fill="url(#pattern0)"/>
+<rect width="344" height="344" rx="20" fill="url(#pattern0)"/>
 </g>
 <defs>
 <pattern id="pattern0" patternContentUnits="objectBoundingBox" width="1" height="1">

--- a/design-at-cornell/src/static/images/orgs_icon.svg
+++ b/design-at-cornell/src/static/images/orgs_icon.svg
@@ -1,5 +1,5 @@
-<svg width="344" height="346" viewBox="0 0 344 346" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-<rect y="2" width="344" height="344" rx="20" fill="#00C8C8"/>
+<svg width="346" height="346" viewBox="0 0 346 346" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<rect width="344" height="344" rx="20" fill="#00C8C8"/>
 <g style="mix-blend-mode:overlay">
 <rect width="344" height="344" rx="20" fill="url(#pattern0)"/>
 </g>


### PR DESCRIPTION
# Summary 

Fixed the covering SVGs for the homepage so that they don't clip anymore. 

Also makes the front end hit the production backend now.  (Need the correct `.env` file though). 

