### PR TITLE
Update majors & minors page filtering and implement majors & minors page mobile version

### DIFF
--- a/design-at-cornell/src/areas-of-study/AreasOfStudy.tsx
+++ b/design-at-cornell/src/areas-of-study/AreasOfStudy.tsx
@@ -29,18 +29,28 @@ const AreasOfStudy = () => {
   const [minors, setMinors] = useState<Major[]>([]);
   const [gradStudies, setGradStudies] = useState<Major[]>([]);
 
-  const [designAreaTags, setDesignAreaTags] = useState<Filters>({ ...designAreas });
+  const [designAreaTags, setDesignAreaTags] = useState<Filters>({ ...designAreas, all: true });
 
-  const [schoolTags, setSchoolTags] = useState<Filters>({ ...schools });
+  const [schoolTags, setSchoolTags] = useState<Filters>({ ...schools, all: true });
+
+  const filterResult = (studies: Major[]) =>
+    studies.filter(
+      (study) =>
+        study.content.designAreas.reduce(
+          (acc, area) => acc || designAreaTags[area],
+          designAreaTags['all']
+        ) &&
+        (schoolTags['all'] || schoolTags[study.content.school])
+    );
 
   return (
     <VerticalFlex>
       <Title />
       <Dashboard
         {...{
-          majors: majors,
-          minors: minors,
-          gradStudies: gradStudies,
+          majors: filterResult(majors),
+          minors: filterResult(minors),
+          gradStudies: filterResult(gradStudies),
           designAreaTags: designAreaTags,
           schoolTags: schoolTags,
           setDesignTags: setDesignAreaTags,

--- a/design-at-cornell/src/areas-of-study/AreasOfStudy.tsx
+++ b/design-at-cornell/src/areas-of-study/AreasOfStudy.tsx
@@ -5,6 +5,7 @@ import Title from './title/Title';
 import Dashboard from './dashboard/Dashboard';
 import { Filters, designAreas, schools } from '../constants/filter-criteria';
 import { Major } from '../../../server/src/types';
+import MobileAreaOfStudyPagination from '../pagination/MobileAreasOfStudyPagination';
 
 const AreasOfStudy = () => {
   useEffect(() => {
@@ -33,6 +34,8 @@ const AreasOfStudy = () => {
 
   const [schoolTags, setSchoolTags] = useState<Filters>({ ...schools, all: true });
 
+  const [pages, setPages] = useState<String[]>(['Majors', 'Graduate', 'Minors']);
+
   const filterResult = (studies: Major[]) =>
     studies.filter(
       (study) =>
@@ -55,8 +58,11 @@ const AreasOfStudy = () => {
           schoolTags: schoolTags,
           setDesignTags: setDesignAreaTags,
           setSchoolTags: setSchoolTags,
+          pages: pages,
+          setPages: setPages,
         }}
       />
+      <MobileAreaOfStudyPagination pages={pages} paginate={setPages} />
     </VerticalFlex>
   );
 };

--- a/design-at-cornell/src/areas-of-study/AreasOfStudyStyles.ts
+++ b/design-at-cornell/src/areas-of-study/AreasOfStudyStyles.ts
@@ -6,6 +6,10 @@ export const DashboardContainer = styled.div`
   flex-direction: row;
   width: 100%;
   height: fit-content;
+
+  @media (max-width: 901px) {
+    flex-direction: column;
+  }
 `;
 
 export const StudiesContainer = styled.div`
@@ -14,6 +18,11 @@ export const StudiesContainer = styled.div`
   width: 80%;
   height: fit-content;
   padding: 60px 90px;
+
+  @media (max-width: 901px) {
+    width: 100%;
+    padding: 25px;
+  }
 `;
 
 export const Divider = styled.div`
@@ -37,6 +46,16 @@ export const Divider = styled.div`
     border: 4px solid #8ed663;
     margin-left: 20px;
   }
+
+  @media (max-width: 901px) {
+    h1 {
+      font-size: 22px;
+    }
+
+    hr {
+      border-width: 2.5px;
+    }
+  }
 `;
 
 export const Grid = styled.div`
@@ -57,6 +76,10 @@ export const AreaOfStudyButton = styled.div`
     font-size: 16px;
     color: black;
     cursor: pointer;
+  }
+
+  @media (max-width: 901px) {
+    width: 100%;
   }
 `;
 
@@ -87,6 +110,13 @@ export const ApplyTagsContainer = styled.div`
     line-height: 40px;
     color: black;
     margin: 0;
+  }
+
+  @media (max-width: 901px) {
+    visibility: hidden;
+    width: 0px;
+    height: 0px;
+    padding: 0px;
   }
 `;
 

--- a/design-at-cornell/src/areas-of-study/AreasOfStudyStyles.ts
+++ b/design-at-cornell/src/areas-of-study/AreasOfStudyStyles.ts
@@ -60,8 +60,7 @@ export const AreaOfStudyButton = styled.div`
   }
 `;
 
-export const AreaOfStudyTag = styled.span<{ highlight: boolean }>`
-  background: ${({ highlight }) => (highlight ? colors.yellowHighlight : 'white')};
+export const AreaOfStudyTag = styled.span`
   font-size: 13px;
   color: ${colors.gray};
 `;

--- a/design-at-cornell/src/areas-of-study/AreasOfStudyStyles.ts
+++ b/design-at-cornell/src/areas-of-study/AreasOfStudyStyles.ts
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { colors } from '../constants/colors';
+import { mobileBreakpoint } from '../constants/styling';
 
 export const DashboardContainer = styled.div`
   display: flex;
@@ -7,33 +8,33 @@ export const DashboardContainer = styled.div`
   width: 100%;
   height: fit-content;
 
-  @media (max-width: 901px) {
+  @media (max-width: ${mobileBreakpoint}px) {
     flex-direction: column;
   }
 `;
 
 export const StudiesContainer = styled.div`
-  @media (min-width: 901px) {
+  @media (min-width: ${mobileBreakpoint + 1}px) {
     display: flex;
     flex-direction: column;
     width: 80%;
     height: fit-content;
     padding: 60px 90px;
   }
-  @media (max-width: 901px) {
+  @media (max-width: ${mobileBreakpoint}px) {
     display: none;
   }
 `;
 
 export const MobileStudiesContainer = styled.div`
-  @media (max-width: 901px) {
+  @media (max-width: ${mobileBreakpoint}px) {
     display: flex;
     flex-direction: column;
     width: 100%;
     height: fit-content;
     padding: 25px;
   }
-  @media (min-width: 901px) {
+  @media (min-width: ${mobileBreakpoint + 1}px) {
     display: none;
   }
 `;
@@ -60,7 +61,7 @@ export const Divider = styled.div`
     margin-left: 20px;
   }
 
-  @media (max-width: 901px) {
+  @media (max-width: ${mobileBreakpoint}px) {
     h1 {
       font-size: 22px;
     }
@@ -91,7 +92,7 @@ export const AreaOfStudyButton = styled.div`
     cursor: pointer;
   }
 
-  @media (max-width: 901px) {
+  @media (max-width: ${mobileBreakpoint}px) {
     width: 100%;
   }
 `;
@@ -125,7 +126,7 @@ export const ApplyTagsContainer = styled.div`
     margin: 0;
   }
 
-  @media (max-width: 901px) {
+  @media (max-width: ${mobileBreakpoint}px) {
     display: none;
   }
 `;

--- a/design-at-cornell/src/areas-of-study/AreasOfStudyStyles.ts
+++ b/design-at-cornell/src/areas-of-study/AreasOfStudyStyles.ts
@@ -13,15 +13,28 @@ export const DashboardContainer = styled.div`
 `;
 
 export const StudiesContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  width: 80%;
-  height: fit-content;
-  padding: 60px 90px;
-
+  @media (min-width: 901px) {
+    display: flex;
+    flex-direction: column;
+    width: 80%;
+    height: fit-content;
+    padding: 60px 90px;
+  }
   @media (max-width: 901px) {
+    display: none;
+  }
+`;
+
+export const MobileStudiesContainer = styled.div`
+  @media (max-width: 901px) {
+    display: flex;
+    flex-direction: column;
     width: 100%;
+    height: fit-content;
     padding: 25px;
+  }
+  @media (min-width: 901px) {
+    display: none;
   }
 `;
 
@@ -113,10 +126,7 @@ export const ApplyTagsContainer = styled.div`
   }
 
   @media (max-width: 901px) {
-    visibility: hidden;
-    width: 0px;
-    height: 0px;
-    padding: 0px;
+    display: none;
   }
 `;
 

--- a/design-at-cornell/src/areas-of-study/dashboard/ApplyTags.tsx
+++ b/design-at-cornell/src/areas-of-study/dashboard/ApplyTags.tsx
@@ -1,25 +1,38 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { ApplyTagsContainer } from '../AreasOfStudyStyles';
 import { Filters, SetFilters } from '../../constants/filter-criteria';
 import { Form } from '../../components/FormStyles';
 
 const ApplyTags = (props: Props) => {
-  const checkboxes = (tags: Filters, setter: SetFilters) => (
+  const [numDesignAreasApplied, setNumDesignAreasApplied] = useState<number>(0);
+  const [numSchoolsApplied, setNumSchoolsApplied] = useState<number>(0);
+
+  const checkboxes = (
+    tags: Filters,
+    setter: SetFilters,
+    numApplied: number,
+    setNumApplied: React.Dispatch<React.SetStateAction<number>>
+  ) => (
     <Form>
-      {Object.entries(tags).map(([tag, _]) => (
-        <div key={tag}>
-          <input
-            type="checkbox"
-            id={tag}
-            onChange={(event) => {
-              const newTags = { ...tags };
-              newTags[tag] = event.target.checked;
-              setter(newTags);
-            }}
-          />
-          <label htmlFor={tag}>{tag}</label>
-        </div>
-      ))}
+      {Object.entries(tags).map(([tag, _]) =>
+        tag === 'all' ? null : (
+          <div key={tag}>
+            <input
+              type="checkbox"
+              id={tag}
+              onChange={(event) => {
+                const newNumApplied = numApplied + (event.target.checked ? 1 : -1);
+                const newTags = { ...tags };
+                newTags[tag] = event.target.checked;
+                newTags['all'] = newNumApplied === 0;
+                setNumApplied(newNumApplied);
+                setter(newTags);
+              }}
+            />
+            <label htmlFor={tag}>{tag}</label>
+          </div>
+        )
+      )}
     </Form>
   );
 
@@ -27,9 +40,14 @@ const ApplyTags = (props: Props) => {
     <ApplyTagsContainer>
       <h5>Apply Tags</h5>
       <h6>Design Areas</h6>
-      {checkboxes(props.designAreaTags, props.setDesignAreaTags)}
+      {checkboxes(
+        props.designAreaTags,
+        props.setDesignAreaTags,
+        numDesignAreasApplied,
+        setNumDesignAreasApplied
+      )}
       <h6>Schools</h6>
-      {checkboxes(props.schoolTags, props.setSchoolTags)}
+      {checkboxes(props.schoolTags, props.setSchoolTags, numSchoolsApplied, setNumSchoolsApplied)}
     </ApplyTagsContainer>
   );
 };

--- a/design-at-cornell/src/areas-of-study/dashboard/ApplyTagsDropdown.tsx
+++ b/design-at-cornell/src/areas-of-study/dashboard/ApplyTagsDropdown.tsx
@@ -1,0 +1,75 @@
+import React, { useState } from 'react';
+import {
+  MobileFilterButton,
+  MobileFilterDropdownContainer,
+  MobileLargeFilterFormContainer,
+} from '../../components/FilterBarStyles';
+import { Filters, SetFilters } from '../../constants/filter-criteria';
+import downArrow from '../../static/images/down-arrow.png';
+import exit from '../../static/images/exit.svg';
+import { Form } from '../../components/FormStyles';
+
+const ApplyTagsDropdown = (props: Props) => {
+  const [expand, setExpand] = useState<boolean>(false);
+  const [numDesignAreasApplied, setNumDesignAreasApplied] = useState<number>(0);
+  const [numSchoolsApplied, setNumSchoolsApplied] = useState<number>(0);
+
+  const filterForm = (
+    tags: Filters,
+    setter: SetFilters,
+    numApplied: number,
+    setNumApplied: React.Dispatch<React.SetStateAction<number>>
+  ) => (
+    <Form>
+      {Object.entries(tags).map(([tag, _]) =>
+        tag === 'all' ? null : (
+          <div key={tag}>
+            <input
+              type="checkbox"
+              id={tag}
+              onChange={(event) => {
+                const newNumApplied = numApplied + (event.target.checked ? 1 : -1);
+                const newTags = { ...tags };
+                newTags[tag] = event.target.checked;
+                newTags['all'] = newNumApplied === 0;
+                setNumApplied(newNumApplied);
+                setter(newTags);
+              }}
+            />
+            <label htmlFor={tag}>{tag}</label>
+          </div>
+        )
+      )}
+    </Form>
+  );
+
+  return (
+    <MobileFilterDropdownContainer>
+      <MobileFilterButton onClick={() => setExpand(!expand)} expand={expand}>
+        <p>Filters</p>
+        <img src={downArrow} alt={'expand'} />
+      </MobileFilterButton>
+      <MobileLargeFilterFormContainer expand={expand}>
+        <img onClick={() => setExpand(false)} src={exit} alt="close" />
+        <h4>Design Areas</h4>
+        {filterForm(
+          props.designAreaTags,
+          props.setDesignAreaTags,
+          numDesignAreasApplied,
+          setNumDesignAreasApplied
+        )}
+        <h4>Schools</h4>
+        {filterForm(props.schoolTags, props.setSchoolTags, numSchoolsApplied, setNumSchoolsApplied)}
+      </MobileLargeFilterFormContainer>
+    </MobileFilterDropdownContainer>
+  );
+};
+
+type Props = {
+  designAreaTags: Filters;
+  schoolTags: Filters;
+  setDesignAreaTags: SetFilters;
+  setSchoolTags: SetFilters;
+};
+
+export default ApplyTagsDropdown;

--- a/design-at-cornell/src/areas-of-study/dashboard/AreaOfStudyCard.tsx
+++ b/design-at-cornell/src/areas-of-study/dashboard/AreaOfStudyCard.tsx
@@ -10,13 +10,9 @@ const AreaOfStudyCard = (props: Props) => {
       onClick={() => window.open(props.study.content.departmentPage)}
     >
       <h1>{props.study.content.title}</h1>
-      <AreaOfStudyTag highlight={props.schoolTags[props.study.content.school]}>
-        {props.study.content.school + '. '}
-      </AreaOfStudyTag>
+      <AreaOfStudyTag>{props.study.content.school + '. '}</AreaOfStudyTag>
       {props.study.content.designAreas.map((area) =>
-        area === '' ? null : (
-          <AreaOfStudyTag highlight={props.designAreaTags[area]}>{area + '. '}</AreaOfStudyTag>
-        )
+        area === '' ? null : <AreaOfStudyTag>{area + '. '}</AreaOfStudyTag>
       )}
     </AreaOfStudyButton>
   );

--- a/design-at-cornell/src/areas-of-study/dashboard/AreaOfStudyModal.tsx
+++ b/design-at-cornell/src/areas-of-study/dashboard/AreaOfStudyModal.tsx
@@ -26,13 +26,9 @@ const AreaOfStudyModal = (props: Props) => {
   const areaOfStudyButton = (
     <AreaOfStudyButton key={props.study.content.title}>
       <h1>{props.study.content.title}</h1>
-      <AreaOfStudyTag highlight={props.schoolTags[props.study.content.school]}>
-        {props.study.content.school + '. '}
-      </AreaOfStudyTag>
+      <AreaOfStudyTag>{props.study.content.school + '. '}</AreaOfStudyTag>
       {props.study.content.designAreas.map((area) =>
-        area === '' ? null : (
-          <AreaOfStudyTag highlight={props.designAreaTags[area]}>{area + '. '}</AreaOfStudyTag>
-        )
+        area === '' ? null : <AreaOfStudyTag>{area + '. '}</AreaOfStudyTag>
       )}
     </AreaOfStudyButton>
   );

--- a/design-at-cornell/src/areas-of-study/dashboard/Dashboard.tsx
+++ b/design-at-cornell/src/areas-of-study/dashboard/Dashboard.tsx
@@ -1,10 +1,17 @@
 import React from 'react';
-import { DashboardContainer, StudiesContainer, Divider } from '../AreasOfStudyStyles';
+import {
+  DashboardContainer,
+  StudiesContainer,
+  MobileStudiesContainer,
+  Divider,
+} from '../AreasOfStudyStyles';
 import StudiesGrid from './StudiesGrid';
 import { Major } from '../../../../server/src/types';
 import { Filters, SetFilters } from '../../constants/filter-criteria';
 import ApplyTags from './ApplyTags';
-import ApplyTagsDropdown from './ApplyTagsDropdown';
+import TagsDropdown from './TagsDropdown';
+import PageDropdown from './PageDropdown';
+import { MobileFilterBarContainer } from '../../components/FilterBarStyles';
 
 const Dashboard = (props: Props) => {
   const studies = (category: string, studies: Major[]) => (
@@ -25,19 +32,32 @@ const Dashboard = (props: Props) => {
 
   return (
     <DashboardContainer>
-      <ApplyTagsDropdown
-        {...{
-          designAreaTags: props.designAreaTags,
-          schoolTags: props.schoolTags,
-          setDesignAreaTags: props.setDesignTags,
-          setSchoolTags: props.setSchoolTags,
-        }}
-      />
+      <MobileFilterBarContainer>
+        <PageDropdown
+          {...{
+            pages: props.pages,
+            setPages: props.setPages,
+          }}
+        />
+        <TagsDropdown
+          {...{
+            designAreaTags: props.designAreaTags,
+            schoolTags: props.schoolTags,
+            setDesignAreaTags: props.setDesignTags,
+            setSchoolTags: props.setSchoolTags,
+          }}
+        />
+      </MobileFilterBarContainer>
       <StudiesContainer>
         {studies('Undergraduate Majors', props.majors)}
         {studies('Undergraduate Minors', props.minors)}
         {studies('Graduate Studies', props.gradStudies)}
       </StudiesContainer>
+      <MobileStudiesContainer>
+        {props.pages[0] === 'Majors' && studies('Undergraduate Majors', props.majors)}
+        {props.pages[0] === 'Minors' && studies('Undergraduate Minors', props.minors)}
+        {props.pages[0] === 'Graduate' && studies('Graduate Studies', props.gradStudies)}
+      </MobileStudiesContainer>
       <ApplyTags
         {...{
           designAreaTags: props.designAreaTags,
@@ -58,6 +78,8 @@ type Props = {
   schoolTags: Filters;
   setDesignTags: SetFilters;
   setSchoolTags: SetFilters;
+  pages: String[];
+  setPages: React.Dispatch<React.SetStateAction<String[]>>;
 };
 
 export default Dashboard;

--- a/design-at-cornell/src/areas-of-study/dashboard/Dashboard.tsx
+++ b/design-at-cornell/src/areas-of-study/dashboard/Dashboard.tsx
@@ -4,6 +4,7 @@ import StudiesGrid from './StudiesGrid';
 import { Major } from '../../../../server/src/types';
 import { Filters, SetFilters } from '../../constants/filter-criteria';
 import ApplyTags from './ApplyTags';
+import ApplyTagsDropdown from './ApplyTagsDropdown';
 
 const Dashboard = (props: Props) => {
   const studies = (category: string, studies: Major[]) => (
@@ -24,6 +25,14 @@ const Dashboard = (props: Props) => {
 
   return (
     <DashboardContainer>
+      <ApplyTagsDropdown
+        {...{
+          designAreaTags: props.designAreaTags,
+          schoolTags: props.schoolTags,
+          setDesignAreaTags: props.setDesignTags,
+          setSchoolTags: props.setSchoolTags,
+        }}
+      />
       <StudiesContainer>
         {studies('Undergraduate Majors', props.majors)}
         {studies('Undergraduate Minors', props.minors)}

--- a/design-at-cornell/src/areas-of-study/dashboard/PageDropdown.tsx
+++ b/design-at-cornell/src/areas-of-study/dashboard/PageDropdown.tsx
@@ -1,0 +1,67 @@
+import React, { useState } from 'react';
+import {
+  MobileFilterButton,
+  MobileFilterDropdownContainer,
+  MobileSelectFormContainer,
+} from '../../components/FilterBarStyles';
+import downArrow from '../../static/images/down-arrow.png';
+import exit from '../../static/images/exit.svg';
+
+const PageDropdown = (props: Props) => {
+  const pageNames = [
+    { value: 'Majors', label: 'Undergraduate Majors' },
+    { value: 'Minors', label: 'Undergraduate Minors' },
+    { value: 'Graduate', label: 'Graduate Studies' },
+  ];
+
+  const [expand, setExpand] = useState<boolean>(false);
+
+  const buttonHandler = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    let currIndex = props.pages.findIndex((page) => page === event.currentTarget.value);
+    props.setPages([
+      props.pages[currIndex],
+      props.pages[(currIndex + 1) % 3],
+      props.pages[(currIndex + 2) % 3],
+    ]);
+    setExpand(false);
+  };
+
+  const filterForm = (
+    pages: String[],
+    setPages: React.Dispatch<React.SetStateAction<String[]>>
+  ) => (
+    <div>
+      <button value={pageNames[0].value} onClick={buttonHandler}>
+        {pageNames[0].label}
+      </button>
+      <button value={pageNames[1].value} onClick={buttonHandler}>
+        {pageNames[1].label}
+      </button>
+      <button value={pageNames[2].value} onClick={buttonHandler}>
+        {pageNames[2].label}
+      </button>
+    </div>
+  );
+
+  return (
+    <MobileFilterDropdownContainer>
+      <MobileFilterButton onClick={() => setExpand(!expand)} expand={expand}>
+        <p>{pageNames.find((page) => page.value === props.pages[0])?.label}</p>
+        <img src={downArrow} alt={'expand'} />
+      </MobileFilterButton>
+      <MobileSelectFormContainer expand={expand}>
+        <img onClick={() => setExpand(false)} src={exit} alt="close" />
+        <h4>Academic Level</h4>
+        {filterForm(props.pages, props.setPages)}
+      </MobileSelectFormContainer>
+    </MobileFilterDropdownContainer>
+  );
+};
+
+type Props = {
+  pages: String[];
+  setPages: React.Dispatch<React.SetStateAction<String[]>>;
+};
+
+export default PageDropdown;

--- a/design-at-cornell/src/areas-of-study/dashboard/TagsDropdown.tsx
+++ b/design-at-cornell/src/areas-of-study/dashboard/TagsDropdown.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import {
   MobileFilterButton,
   MobileFilterDropdownContainer,
-  MobileLargeFilterFormContainer,
+  CenteredMobileLargeFilterFormContainer,
 } from '../../components/FilterBarStyles';
 import { Filters, SetFilters } from '../../constants/filter-criteria';
 import downArrow from '../../static/images/down-arrow.png';
@@ -49,7 +49,7 @@ const TagsDropdown = (props: Props) => {
         <p>Filters</p>
         <img src={downArrow} alt={'expand'} />
       </MobileFilterButton>
-      <MobileLargeFilterFormContainer expand={expand}>
+      <CenteredMobileLargeFilterFormContainer expand={expand}>
         <img onClick={() => setExpand(false)} src={exit} alt="close" />
         <h4>Design Areas</h4>
         {filterForm(
@@ -60,7 +60,7 @@ const TagsDropdown = (props: Props) => {
         )}
         <h4>Schools</h4>
         {filterForm(props.schoolTags, props.setSchoolTags, numSchoolsApplied, setNumSchoolsApplied)}
-      </MobileLargeFilterFormContainer>
+      </CenteredMobileLargeFilterFormContainer>
     </MobileFilterDropdownContainer>
   );
 };

--- a/design-at-cornell/src/areas-of-study/dashboard/TagsDropdown.tsx
+++ b/design-at-cornell/src/areas-of-study/dashboard/TagsDropdown.tsx
@@ -9,7 +9,7 @@ import downArrow from '../../static/images/down-arrow.png';
 import exit from '../../static/images/exit.svg';
 import { Form } from '../../components/FormStyles';
 
-const ApplyTagsDropdown = (props: Props) => {
+const TagsDropdown = (props: Props) => {
   const [expand, setExpand] = useState<boolean>(false);
   const [numDesignAreasApplied, setNumDesignAreasApplied] = useState<number>(0);
   const [numSchoolsApplied, setNumSchoolsApplied] = useState<number>(0);
@@ -72,4 +72,4 @@ type Props = {
   setSchoolTags: SetFilters;
 };
 
-export default ApplyTagsDropdown;
+export default TagsDropdown;

--- a/design-at-cornell/src/components/FilterBarStyles.ts
+++ b/design-at-cornell/src/components/FilterBarStyles.ts
@@ -17,6 +17,14 @@ export const FilterBarContainer = styled.div`
   }
 `;
 
+export const MobileFilterBarContainer = styled(FilterBarContainer)`
+  justify-content: center;
+
+  @media (min-width: 901px) {
+    display: none;
+  }
+`;
+
 export const FilterDropdownContainer = styled.li`
   position: relative;
   display: inline;
@@ -34,9 +42,7 @@ export const MobileFilterDropdownContainer = styled(FilterDropdownContainer)`
   align-self: flex-end;
   margin: 20px 20px 0px 20px;
   @media (min-width: 901px) {
-    visibility: hidden;
-    width: 0px;
-    margin: 0px;
+    display: none;
   }
 `;
 
@@ -69,8 +75,7 @@ export const MobileFilterButton = styled(FilterButton)`
   visibility: ${({ expand }) => (!expand ? 'visible' : 'hidden')};
 
   @media (min-width: 901px) {
-    visibility: hidden;
-    width: 0px;
+    display: none;
   }
 `;
 
@@ -104,10 +109,41 @@ export const MobileLargeFilterFormContainer = styled(LargeFilterFormContainer)`
     position: absolute;
     padding-top: 15px;
     left: 90%;
+    cursor: pointer;
   }
 
   h4 {
     margin: 12px 0px 5px 0px;
+  }
+`;
+
+export const MobileSelectFormContainer = styled(MobileLargeFilterFormContainer)`
+  margin-top: -100px;
+
+  div {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  img {
+    left: 85%;
+  }
+
+  button {
+    background-color: transparent;
+    border: 0px solid transparent;
+    padding-top: 5px;
+    margin-left: -5px;
+    font-family: 'Work Sans';
+    font-weight: bold;
+    font-size: 12px;
+    line-height: 19px;
+    cursor: pointer;
+  }
+
+  button:hover {
+    color: ${colors.green};
   }
 `;
 

--- a/design-at-cornell/src/components/FilterBarStyles.ts
+++ b/design-at-cornell/src/components/FilterBarStyles.ts
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import { colors } from '../constants/colors';
 import magnifyingGlass from '../static/images/magnifying-glass.svg';
+import { mobileBreakpoint } from '../constants/styling';
 
 export const FilterBarContainer = styled.div`
   display: flex;
@@ -20,7 +21,7 @@ export const FilterBarContainer = styled.div`
 export const MobileFilterBarContainer = styled(FilterBarContainer)`
   justify-content: center;
 
-  @media (min-width: 901px) {
+  @media (min-width: ${mobileBreakpoint + 1}px) {
     display: none;
   }
 `;
@@ -41,7 +42,7 @@ export const FilterDropdownContainer = styled.li`
 export const MobileFilterDropdownContainer = styled(FilterDropdownContainer)`
   align-self: flex-end;
   margin: 20px 20px 0px 20px;
-  @media (min-width: 901px) {
+  @media (min-width: ${mobileBreakpoint + 1}px) {
     display: none;
   }
 `;
@@ -74,7 +75,7 @@ export const MobileFilterButton = styled(FilterButton)`
   padding: 5px 15px;
   visibility: ${({ expand }) => (!expand ? 'visible' : 'hidden')};
 
-  @media (min-width: 901px) {
+  @media (min-width: ${mobileBreakpoint + 1}px) {
     display: none;
   }
 `;

--- a/design-at-cornell/src/components/FilterBarStyles.ts
+++ b/design-at-cornell/src/components/FilterBarStyles.ts
@@ -117,6 +117,12 @@ export const MobileLargeFilterFormContainer = styled(LargeFilterFormContainer)`
   }
 `;
 
+export const CenteredMobileLargeFilterFormContainer = styled(MobileLargeFilterFormContainer)`
+  width: 350px;
+  right: -2vw;
+  border: 5px solid white;
+`;
+
 export const MobileSelectFormContainer = styled(MobileLargeFilterFormContainer)`
   margin-top: -100px;
 

--- a/design-at-cornell/src/components/FilterBarStyles.ts
+++ b/design-at-cornell/src/components/FilterBarStyles.ts
@@ -35,6 +35,8 @@ export const MobileFilterDropdownContainer = styled(FilterDropdownContainer)`
   margin: 20px 20px 0px 20px;
   @media (min-width: 901px) {
     visibility: hidden;
+    width: 0px;
+    margin: 0px;
   }
 `;
 
@@ -65,6 +67,11 @@ export const MobileFilterButton = styled(FilterButton)`
   height: 36px;
   padding: 5px 15px;
   visibility: ${({ expand }) => (!expand ? 'visible' : 'hidden')};
+
+  @media (min-width: 901px) {
+    visibility: hidden;
+    width: 0px;
+  }
 `;
 
 export const FilterFormContainer = styled.div<{ expand: boolean }>`

--- a/design-at-cornell/src/components/FilterBarStyles.ts
+++ b/design-at-cornell/src/components/FilterBarStyles.ts
@@ -21,12 +21,20 @@ export const FilterDropdownContainer = styled.li`
   position: relative;
   display: inline;
   box-sizing: border-box;
-  margin: 0 10px;
+  margin: 10px 10px 0px 10px;
   p {
     font-weight: bold;
     font-size: 12px;
     margin-right: 20px;
     margin-top: 4px;
+  }
+`;
+
+export const MobileFilterDropdownContainer = styled(FilterDropdownContainer)`
+  align-self: flex-end;
+  margin: 20px 20px 0px 20px;
+  @media (min-width: 901px) {
+    visibility: hidden;
   }
 `;
 
@@ -51,6 +59,14 @@ export const FilterButton = styled.div<{ expand: boolean }>`
   }
 `;
 
+export const MobileFilterButton = styled(FilterButton)`
+  border-radius: 15px;
+  box-shadow: 0px 0px 5px 2px ${colors.cardShadow};
+  height: 36px;
+  padding: 5px 15px;
+  visibility: ${({ expand }) => (!expand ? 'visible' : 'hidden')};
+`;
+
 export const FilterFormContainer = styled.div<{ expand: boolean }>`
   width: 100%;
   position: absolute;
@@ -63,7 +79,7 @@ export const FilterFormContainer = styled.div<{ expand: boolean }>`
 
 export const LargeFilterFormContainer = styled.div<{ expand: boolean }>`
   width: fit-content;
-  height: 340px;
+  height: fit-content;
   position: absolute;
   white-space: nowrap;
   display: ${({ expand }) => (expand ? 'inline' : 'none')};
@@ -71,6 +87,21 @@ export const LargeFilterFormContainer = styled.div<{ expand: boolean }>`
   padding: 0px 15px 15px 15px;
   border-radius: 0 15px 15px 15px;
   box-shadow: 0px 20px 20px 10px ${colors.shadow};
+`;
+
+export const MobileLargeFilterFormContainer = styled(LargeFilterFormContainer)`
+  margin-top: -150px;
+  border-radius: 15px;
+
+  img {
+    position: absolute;
+    padding-top: 15px;
+    left: 90%;
+  }
+
+  h4 {
+    margin: 12px 0px 5px 0px;
+  }
 `;
 
 export const SearchBar = styled.input`

--- a/design-at-cornell/src/components/TitleStyles.ts
+++ b/design-at-cornell/src/components/TitleStyles.ts
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { colors } from '../constants/colors';
+import { mobileBreakpoint } from '../constants/styling';
 
 export const TitleBackground = styled.div`
   display: flex;
@@ -10,7 +11,7 @@ export const TitleBackground = styled.div`
   padding-left: 100px;
   padding-right: 100px;
 
-  @media (max-width: 901px) {
+  @media (max-width: ${mobileBreakpoint}px) {
     padding-left: 50px;
     padding-right: 50px;
     height: 300px;
@@ -49,7 +50,7 @@ export const TitleContainer = styled.div`
     padding-left: 5px;
   }
 
-  @media (max-width: 901px) {
+  @media (max-width: ${mobileBreakpoint}px) {
     h1 {
       font-size: 36px;
       line-height: 48px;

--- a/design-at-cornell/src/components/TitleStyles.ts
+++ b/design-at-cornell/src/components/TitleStyles.ts
@@ -9,6 +9,12 @@ export const TitleBackground = styled.div`
   background: ${(props) => props.color};
   padding-left: 100px;
   padding-right: 100px;
+
+  @media (max-width: 901px) {
+    padding-left: 50px;
+    padding-right: 50px;
+    height: 300px;
+  }
 `;
 
 export const TitleBackgroundImage = styled.div`
@@ -41,6 +47,20 @@ export const TitleContainer = styled.div`
     text-align: left;
     color: black;
     padding-left: 5px;
+  }
+
+  @media (max-width: 901px) {
+    h1 {
+      font-size: 36px;
+      line-height: 48px;
+    }
+
+    p {
+      font-size: 18px;
+      line-height: 24px;
+    }
+
+    width: 100%;
   }
 `;
 

--- a/design-at-cornell/src/pagination/MobileAreasOfStudyPagination.tsx
+++ b/design-at-cornell/src/pagination/MobileAreasOfStudyPagination.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import {
+  MobileAreaOfStudyStyledPagination,
+  MobileAreaOfStudyPageNavButton,
+} from './PaginationStyles';
+import rightArrow from '../static/images/right-arrow.svg';
+
+const MobileAreaOfStudyPagination = ({ pages, paginate }: Props) => {
+  return (
+    <MobileAreaOfStudyStyledPagination>
+      <ul>
+        <MobileAreaOfStudyPageNavButton
+          direction="left"
+          onClick={() => paginate([pages[1], pages[2], pages[0]])}
+        >
+          <img src={rightArrow} alt="prev page" />
+          {pages[1]}
+        </MobileAreaOfStudyPageNavButton>
+        <MobileAreaOfStudyPageNavButton
+          direction="right"
+          onClick={() => paginate([pages[2], pages[0], pages[1]])}
+        >
+          {pages[2]}
+          <img src={rightArrow} alt="next page" />
+        </MobileAreaOfStudyPageNavButton>
+      </ul>
+    </MobileAreaOfStudyStyledPagination>
+  );
+};
+
+export default MobileAreaOfStudyPagination;
+
+interface Props {
+  pages: String[];
+  paginate(pages: String[]): void;
+}

--- a/design-at-cornell/src/pagination/PaginationStyles.ts
+++ b/design-at-cornell/src/pagination/PaginationStyles.ts
@@ -27,6 +27,21 @@ export const StyledPagination = styled.div`
   }
 `;
 
+export const MobileAreaOfStudyStyledPagination = styled(StyledPagination)`
+  margin-top: -25px;
+  margin-bottom: 25px;
+  padding: 0px 10px;
+
+  @media (min-width: 901px) {
+    display: none;
+  }
+
+  ul {
+    width: 100%;
+    justify-content: space-between;
+  }
+`;
+
 export const PageButton = styled.button<{ selected: boolean }>`
   width: 41px;
   height: 41px;
@@ -57,7 +72,6 @@ export const PageNavButton = styled.button<{ direction: string }>`
   line-height: 41px;
   text-align: center;
   align-items: center;
-  justify-content: ${({ direction }) => (direction === 'left' ? 'flex-start' : 'flex-end')};
   cursor: pointer;
 
   img {
@@ -69,4 +83,10 @@ export const PageNavButton = styled.button<{ direction: string }>`
     border: none;
     outline: none;
   }
+`;
+
+export const MobileAreaOfStudyPageNavButton = styled(PageNavButton)`
+  font-size: 16px;
+  line-height: 20px;
+  width: fit-content;
 `;

--- a/design-at-cornell/src/pagination/PaginationStyles.ts
+++ b/design-at-cornell/src/pagination/PaginationStyles.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { mobileBreakpoint } from '../constants/styling';
 
 export const StyledPagination = styled.div`
   display: flex;
@@ -32,7 +33,7 @@ export const MobileAreaOfStudyStyledPagination = styled(StyledPagination)`
   margin-bottom: 25px;
   padding: 0px 10px;
 
-  @media (min-width: 901px) {
+  @media (min-width: ${mobileBreakpoint + 1}px) {
     display: none;
   }
 


### PR DESCRIPTION
### Summary <!-- Required -->

This PR updates the filtering by tags on the Majors & Minors page and also implements the Majors & Minors page mobile version. 

Instead of highlighting the majors and minors that have the applied tags, the majors and minors are removed/added to the page based on the applied tags. 

The mobile version of the Majors & Minors page is similar to the desktop version but moves the tags from the side of the page to a dropdown bar and contains three different pages for Undergraduate Majors, Undergraduate Minors, and Graduate Studies (to control which page the user is on they can either choose from a dropdown bar or control the pages with the pagination at the bottom of the page).

